### PR TITLE
attribute_view_gui function width and height

### DIFF
--- a/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/view/ezgmaplocation.tpl
+++ b/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/view/ezgmaplocation.tpl
@@ -1,10 +1,11 @@
-{* Make sure to normalize floats from db  *}
 {if is_unset( $width )}
     {def $width=500}
 {/if}
 {if is_unset( $height )}
     {def $height=280}
 {/if}
+
+{* Make sure to normalize floats from db  *}
 {def $latitude  = $attribute.content.latitude|explode(',')|implode('.')
      $longitude = $attribute.content.longitude|explode(',')|implode('.')}
 {run-once}


### PR DESCRIPTION
More flexibility to attribute_view_gui function, now it's possible to specify width or height:

{attribute_view_gui attribute=$data_map.location width=350 height=210}

Default values still are 500 and 280, so it's back compatible, it isn't mandatory to specify those values.
