### PR TITLE
EZP-24112 - Avoid mixed content blocking in the GMapLocation attribute when using pages over HTTPS

### DIFF
--- a/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/edit/ezgmaplocation.tpl
+++ b/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/edit/ezgmaplocation.tpl
@@ -9,7 +9,7 @@
 
 <div class="element">
 {run-once}
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor={ezini('GMapSettings', 'UseSensor', 'ezgmaplocation.ini')}"></script>
+<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor={ezini('GMapSettings', 'UseSensor', 'ezgmaplocation.ini')}"></script>
 <script type="text/javascript">
 {literal}
 function eZGmapLocation_MapControl( attributeId, latLongAttributeBase )

--- a/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/view/ezgmaplocation.tpl
+++ b/packages/ezgmaplocation_extension/ezextension/ezgmaplocation/design/standard/templates/content/datatype/view/ezgmaplocation.tpl
@@ -9,7 +9,7 @@
 {def $latitude  = $attribute.content.latitude|explode(',')|implode('.')
      $longitude = $attribute.content.longitude|explode(',')|implode('.')}
 {run-once}
-<script type="text/javascript" src="http://maps.google.com/maps/api/js?sensor={ezini('GMapSettings', 'UseSensor', 'ezgmaplocation.ini')}"></script>
+<script type="text/javascript" src="//maps.google.com/maps/api/js?sensor={ezini('GMapSettings', 'UseSensor', 'ezgmaplocation.ini')}"></script>
 <script type="text/javascript">
 {literal}
 function eZGmapLocation_MapView( attributeId, latitude, longitude )


### PR DESCRIPTION
If a website delivers HHTPS pages, all active mixed content delivered via HTTP on this pages will be blocked by default, Consequently, when users use the GMapLocation attribute, this appear broken or disable, for that reason users can not set a location on map.

Currently the solution is create a template override.

Solution is use protocol relative links.